### PR TITLE
Adds check for mysql_history file and creates it if needed.

### DIFF
--- a/src/History.php
+++ b/src/History.php
@@ -10,7 +10,11 @@ class History
 
     public function loadHistory(): void
     {
-        $history = file($this->getHistoryFilePath());
+        $filePath = $this->getHistoryFilePath();
+        if (! file_exists($filePath)) {
+            file_put_contents($filePath, PHP_EOL);
+        } 
+        $history = file($filePath);
 
         foreach ($history as $query) {
             readline_add_history(str_replace('\040', ' ', $query));

--- a/src/History.php
+++ b/src/History.php
@@ -13,7 +13,7 @@ class History
         $filePath = $this->getHistoryFilePath();
         if (! file_exists($filePath)) {
             file_put_contents($filePath, PHP_EOL);
-        } 
+        }
         $history = file($filePath);
 
         foreach ($history as $query) {


### PR DESCRIPTION
Hi, Jamesclark32. I noticed db-shell will give an error if the mysql_history file does not exist, which is common for Docker instances. This pull request adds a check for that file and creates it with an empty line if needed.

Thanks for your efforts here!
